### PR TITLE
Monthly analytics

### DIFF
--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/controller/TransactionController.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/controller/TransactionController.java
@@ -16,21 +16,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -52,7 +46,7 @@ public class TransactionController {
     private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
     @Autowired
-    TransactionService transactionServiceImpl;
+    TransactionService transactionService;
     
   
 
@@ -63,7 +57,7 @@ public class TransactionController {
     public ResponseEntity<?> addTransaction (@RequestBody Transaction transaction){
         securityContext.setContext(SecurityContextHolder.getContext());
         try{
-            Double newBalance = transactionServiceImpl.addTransaction(securityContext.getCurrentUser().getUser_id(), transaction);
+            Double newBalance = transactionService.addTransaction(securityContext.getCurrentUser().getUser_id(), transaction);
             securityContext.dispose();
             return new ResponseEntity<>(newBalance, HttpStatus.OK);
        }
@@ -77,7 +71,7 @@ public class TransactionController {
     public ResponseEntity<?> getTransactionsByType(@PathVariable("transaction_type") String transaction_type) {
         securityContext.setContext(SecurityContextHolder.getContext());
         try {
-            List<Transaction> transactionsList = transactionServiceImpl.getTransactionsByType(securityContext.getCurrentUser().getUser_id(), transaction_type);
+            List<Transaction> transactionsList = transactionService.getTransactionsByType(securityContext.getCurrentUser().getUser_id(), transaction_type);
             securityContext.dispose();
             return new ResponseEntity<>(transactionsList, HttpStatus.OK);
         } catch (TransactionException e) {
@@ -90,7 +84,7 @@ public class TransactionController {
     public ResponseEntity<?> getThisMonthTotalAmount(@PathVariable TransactionType transactionType) {
         securityContext.setContext(SecurityContextHolder.getContext());
         try {
-            Double thisMonthIncome = transactionServiceImpl.getThisMonthTotalAmount(securityContext.getCurrentUser().getUser_id(),transactionType);
+            Double thisMonthIncome = transactionService.getThisMonthTotalAmount(securityContext.getCurrentUser().getUser_id(),transactionType);
             securityContext.dispose();
             return new ResponseEntity<>(thisMonthIncome, HttpStatus.OK);
         } catch (TransactionException e) {
@@ -104,9 +98,9 @@ public class TransactionController {
         securityContext.setContext(SecurityContextHolder.getContext());
         System.out.println("Enter to getTexportTransactionsToCsv");
         try {
-            List<Transaction> transactions = transactionServiceImpl.getTransactionsForUser(securityContext.getCurrentUser().getUser_id());
+            List<Transaction> transactions = transactionService.getTransactionsForUser(securityContext.getCurrentUser().getUser_id());
             String csvFilePath = "transaction_history.csv";
-            transactionServiceImpl.exportToCsv(transactions, csvFilePath);
+            transactionService.exportToCsv(transactions, csvFilePath);
 
             // Read the content of the CSV file
             byte[] csvFileContent = Files.readAllBytes(Paths.get(csvFilePath));
@@ -135,7 +129,7 @@ public class TransactionController {
             @PathVariable("year") Integer year) {
         securityContext.setContext(SecurityContextHolder.getContext());
         try {
-            List<Map<Object, Object>> incomes = transactionServiceImpl
+            List<Map<Object, Object>> incomes = transactionService
                     .getMonthlyAnalyticsByYear(securityContext.getCurrentUser().getUser_id(),
                             year,
                             transactionType);

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/controller/TransactionController.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/controller/TransactionController.java
@@ -86,31 +86,17 @@ public class TransactionController {
         }
     }
 
-    @GetMapping("monthly/expense")
-    public ResponseEntity<?> getThisMonthExpense() {
+    @GetMapping("thismonth/{transactionType}")
+    public ResponseEntity<?> getThisMonthTotalAmount(@PathVariable TransactionType transactionType) {
         securityContext.setContext(SecurityContextHolder.getContext());
         try {
-            Double thisMonthExpense = transactionServiceImpl.getThisMonthExpense(securityContext.getCurrentUser().getUser_id());
-            securityContext.dispose();
-            return new ResponseEntity<>(thisMonthExpense, HttpStatus.OK);
-        } catch (TransactionException e) {
-            securityContext.dispose();
-            return new ResponseEntity<>(e.getMessage(),HttpStatus.NO_CONTENT);
-        }
-    }
-
-    @GetMapping("monthly/income")
-    public ResponseEntity<?> getThisMonthIncome() {
-        securityContext.setContext(SecurityContextHolder.getContext());
-        try {
-            Double thisMonthIncome = transactionServiceImpl.getThisMonthIncome(securityContext.getCurrentUser().getUser_id());
+            Double thisMonthIncome = transactionServiceImpl.getThisMonthTotalAmount(securityContext.getCurrentUser().getUser_id(),transactionType);
             securityContext.dispose();
             return new ResponseEntity<>(thisMonthIncome, HttpStatus.OK);
         } catch (TransactionException e) {
             securityContext.dispose();
-            return new ResponseEntity<>(e.getMessage(),HttpStatus.NO_CONTENT);
+            return new ResponseEntity<>(e.getMessage(),HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        
     }
     
     @GetMapping("export/csv")
@@ -143,8 +129,6 @@ public class TransactionController {
         }
     }
 
-  
- 
     @GetMapping("analytics/monthly/{type}/{year}")
     public ResponseEntity<?> getMonthlyAnalyticsByYear(
             @PathVariable("type") TransactionType transactionType,

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/controller/UserAuthenticationController.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/controller/UserAuthenticationController.java
@@ -18,6 +18,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import static com.soloSavings.utils.Constants.INVALID_USERNAME_OR_PASSWORD;
+
 /*
  * Copyright (c) 2023 Team 2 - SoloSavings
  * Boston University MET CS 673 - Software Engineering
@@ -60,7 +62,7 @@ public class UserAuthenticationController {
         try {
             authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(loginData.username(), loginData.password()));
         } catch (BadCredentialsException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid username or password");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(INVALID_USERNAME_OR_PASSWORD);
         }
 
         UserDetails userDetails = userService.loadUserByUsername(loginData.username());

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/model/User.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/model/User.java
@@ -28,6 +28,7 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "users")
 public class User {

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/repository/TransactionRepository.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/repository/TransactionRepository.java
@@ -22,9 +22,6 @@ public interface TransactionRepository extends JpaRepository<Transaction, Intege
     @Query("SELECT t FROM Transaction t WHERE t.user_id = ?1 and t.transaction_type = ?2")
     List<Transaction> findByTransactionType(Integer user_id, TransactionType transaction_type);
 
-    @Query("SELECT e FROM Transaction e WHERE MONTH(e.transaction_date) = MONTH(CURRENT_DATE()) AND YEAR(e.transaction_date) = YEAR(CURRENT_DATE()) AND  e.transaction_type = ?1")
-    List<Transaction> findByCurrentMonth(TransactionType trans_type);
-
     @Query("SELECT e FROM Transaction e WHERE  e.user_id = ?1")
     List<Transaction> findAllByUserId(Integer userId);
 

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/service/TransactionService.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/service/TransactionService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Map;
 
 /*
@@ -25,14 +24,12 @@ public interface TransactionService {
 
     Double addTransaction(Integer user_id, Transaction transaction) throws TransactionException;
 
-    Double getThisMonthExpense(Integer userId) throws TransactionException;
-
-    Double getThisMonthIncome(Integer userId) throws TransactionException;
-    public List<Transaction> getTransactionsForUser(Integer userId) ;
-    public void exportToCsv(List<Transaction> transactions, String filePath) throws IOException ;
-
+    List<Transaction> getTransactionsForUser(Integer userId) ;
+    void exportToCsv(List<Transaction> transactions, String filePath) throws IOException ;
 
     List<Map<Object, Object>> getMonthlyAnalyticsByYear(Integer userId, Integer year, TransactionType transactionType) throws TransactionException;
 
-    Double calculateMonthlyAmount(int month, int year, int userId, TransactionType transType);
+    Double calculateMonthlyAmount(int month, int year, int userId, TransactionType transType) throws TransactionException;
+
+    Double getThisMonthTotalAmount(Integer userId, TransactionType transactionType) throws TransactionException;
 }

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/service/TransactionService.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/service/TransactionService.java
@@ -33,4 +33,6 @@ public interface TransactionService {
 
 
     List<Map<Object, Object>> getMonthlyAnalyticsByYear(Integer userId, Integer year, TransactionType transactionType) throws TransactionException;
+
+    Double calculateMonthlyAmount(int month, int year, int userId, TransactionType transType);
 }

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/utils/Constants.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/utils/Constants.java
@@ -11,5 +11,5 @@ import java.util.List;
  * Team 2 - SoloSavings Application
  */
 public class Constants {
-    public static final String[] listOfMonth = {"January","February","March","April","May","June","July","August","September","October","November","December"};
+    public static final String[] LIST_OF_MONTHS = {"January","February","March","April","May","June","July","August","September","October","November","December"};
 }

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/utils/Constants.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/utils/Constants.java
@@ -16,4 +16,6 @@ public class Constants {
     public static final String INTERNAL_SERVER_ERROR = "Internal Server Error, Please try again later!";
 
     public static final String INVALID_TRANSACTION_AMOUNT = "Invalid transaction amount, Please input correct transaction amount!";
+
+    public static final String INVALID_USERNAME_OR_PASSWORD = "Invalid username or password, Please try again!";
 }

--- a/code/SoloSavingsApp/src/main/java/com/soloSavings/utils/Constants.java
+++ b/code/SoloSavingsApp/src/main/java/com/soloSavings/utils/Constants.java
@@ -12,4 +12,8 @@ import java.util.List;
  */
 public class Constants {
     public static final String[] LIST_OF_MONTHS = {"January","February","March","April","May","June","July","August","September","October","November","December"};
+
+    public static final String INTERNAL_SERVER_ERROR = "Internal Server Error, Please try again later!";
+
+    public static final String INVALID_TRANSACTION_AMOUNT = "Invalid transaction amount, Please input correct transaction amount!";
 }

--- a/code/SoloSavingsApp/src/main/webapp/WEB-INF/views/dashboard.jsp
+++ b/code/SoloSavingsApp/src/main/webapp/WEB-INF/views/dashboard.jsp
@@ -130,7 +130,7 @@
             justify-content: center;
             align-items: center;
         }
-        .add-income-btn, .add-expense-btn{
+         .add-expense-btn, #analytics-button{
             margin: 10px;
         }
         /* Modal Content/Box */
@@ -194,9 +194,13 @@
 
         <!-- Add Income Button -->
         <button class="add-expense-btn">Add Expense</button>
-                <button id="transaction-history-button">Transaction History</button>
-        
-        
+
+        <!-- Transaction History Button -->
+        <button id="transaction-history-button">Transaction History</button>
+
+        <!-- Show 12 mon Button -->
+        <button id="analytics-button">View Analytics</button>
+
     </div>
     <%--income button and modal--%>
 
@@ -444,6 +448,10 @@
                 // Handle the error, e.g., show an error message to the user.
             }
         });
+    });
+
+    $("#analytics-button").click(function() {
+        window.location.replace("analytics");
     });
 </script>
 </html>

--- a/code/SoloSavingsApp/src/main/webapp/WEB-INF/views/dashboard.jsp
+++ b/code/SoloSavingsApp/src/main/webapp/WEB-INF/views/dashboard.jsp
@@ -281,7 +281,7 @@
     $.ajax({
         async: false,
         type: 'GET',
-        url: '/api/transaction/monthly/income',
+        url: '/api/transaction/thismonth/CREDIT',
         contentType: 'application/json',
         success: function(response) {
             thisMonthIncome = response;
@@ -293,7 +293,7 @@
     $.ajax({
         async: false,
         type: 'GET',
-        url: '/api/transaction/monthly/expense',
+        url: '/api/transaction/thismonth/DEBIT',
         contentType: 'application/json',
         success: function(response) {
             thisMonthExpense = response;

--- a/code/SoloSavingsApp/src/main/webapp/WEB-INF/views/register.jsp
+++ b/code/SoloSavingsApp/src/main/webapp/WEB-INF/views/register.jsp
@@ -180,7 +180,7 @@
                 success: function(response) {
                     console.log('Registration successful:', response);
                     confirm("Your account successfully created, redirect to your dashboard.")
-                    window.location.replace("dashboard");
+                    window.location.replace("login");
                 },
                 error: function(error) {
                     alert(error.responseText);

--- a/code/SoloSavingsApp/src/test/java/com/soloSavings/controller/TransactionControllerTest.java
+++ b/code/SoloSavingsApp/src/test/java/com/soloSavings/controller/TransactionControllerTest.java
@@ -6,11 +6,6 @@ import com.soloSavings.model.User;
 import com.soloSavings.model.helper.TransactionType;
 import com.soloSavings.service.SecurityContext;
 import com.soloSavings.service.TransactionService;
-import com.soloSavings.serviceImpl.TransactionServiceImpl;
-
-import jakarta.annotation.Resource;
-
-
 import static com.soloSavings.utils.Constants.INTERNAL_SERVER_ERROR;
 import static org.mockito.ArgumentMatchers.any;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +18,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -119,7 +117,7 @@ public class TransactionControllerTest {
         Double thisMonthIncome = 1000.0; // Set your expected this month's income here
 
         // Mock
-        when(transService.getThisMonthTotalAmount(user.getUser_id(),TransactionType.CREDIT)).thenReturn(thisMonthIncome);
+        when(transService.getThisMonthTotalAmount(anyInt(),any(TransactionType.class))).thenReturn(thisMonthIncome);
         ResponseEntity<?> response = transController.getThisMonthTotalAmount(TransactionType.CREDIT);
 
         // Assert
@@ -129,7 +127,7 @@ public class TransactionControllerTest {
     @Test
     public void testGetThisMonthIncomeWithInvalidRequest() throws TransactionException {
         // Mock
-        when(transService.getThisMonthTotalAmount(user.getUser_id(),TransactionType.CREDIT))
+        when(transService.getThisMonthTotalAmount(anyInt(),any(TransactionType.class)))
                 .thenThrow(new TransactionException(INTERNAL_SERVER_ERROR));
 
         ResponseEntity<?> response = transController.getThisMonthTotalAmount(TransactionType.CREDIT);
@@ -145,7 +143,7 @@ public class TransactionControllerTest {
         Double thisMonthExpense = 500.0;
 
         // Mock
-        when(transService.getThisMonthTotalAmount(user.getUser_id(),TransactionType.DEBIT)).thenReturn(thisMonthExpense);
+        when(transService.getThisMonthTotalAmount(anyInt(),any(TransactionType.class))).thenReturn(thisMonthExpense);
         ResponseEntity<?> response = transController.getThisMonthTotalAmount(TransactionType.DEBIT);
 
         // Assert
@@ -155,7 +153,7 @@ public class TransactionControllerTest {
     @Test
     public void testGetThisMonthExpenseWithInvalidRequest() throws TransactionException {
         // Mock
-        when(transService.getThisMonthTotalAmount(user.getUser_id(),TransactionType.DEBIT))
+        when(transService.getThisMonthTotalAmount(anyInt(),any(TransactionType.class)))
                 .thenThrow(new TransactionException(INTERNAL_SERVER_ERROR));
 
         ResponseEntity<?> response = transController.getThisMonthTotalAmount(TransactionType.DEBIT);
@@ -194,6 +192,34 @@ public class TransactionControllerTest {
         assertEquals(userId, retrievedTransaction.getUser_id());
         assertEquals("stealing", retrievedTransaction.getSource());
         // ... Add more assertions for other properties as needed
+    }
+
+    @Test
+    public void testGetMonthlyAnalyticsByYearError() throws TransactionException {
+        // Mock
+        when(transService.getMonthlyAnalyticsByYear(anyInt(),anyInt(),any(TransactionType.class)))
+                .thenThrow(new TransactionException(INTERNAL_SERVER_ERROR));
+
+        ResponseEntity<?> response = transController.getMonthlyAnalyticsByYear(TransactionType.DEBIT,2023);
+
+        // Assert
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(INTERNAL_SERVER_ERROR, response.getBody());
+    }
+
+    @Test
+    public void testGetMonthlyAnalyticsByYear() throws TransactionException {
+        List<Map<Object, Object>> list = new ArrayList<>();
+
+        // Mock
+        when(transService.getMonthlyAnalyticsByYear(anyInt(),anyInt(),any(TransactionType.class)))
+                .thenReturn(list);
+
+        ResponseEntity<?> response = transController.getMonthlyAnalyticsByYear(TransactionType.DEBIT,2023);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(list, response.getBody());
     }
 }
 

--- a/code/SoloSavingsApp/src/test/java/com/soloSavings/controller/TransactionControllerTest.java
+++ b/code/SoloSavingsApp/src/test/java/com/soloSavings/controller/TransactionControllerTest.java
@@ -17,23 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.plugins.MockMaker;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MvcResult;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,12 +35,6 @@ public class TransactionControllerTest {
     TransactionController transController;
     @Mock
     TransactionService transService;
-    
-
-    @Mock
-    private TransactionServiceImpl transactionServiceImpl;
-
-
     @Mock
     SecurityContext securityContext;
     User user;
@@ -205,11 +185,11 @@ public class TransactionControllerTest {
         // ... Set other properties as needed
 
         // Mock the behavior of transactionServiceImpl
-        when(transactionServiceImpl.getTransactionsForUser(userId))
+        when(transService.getTransactionsForUser(userId))
             .thenReturn(List.of(sampleTransaction));
 
         // Call the method you want to test
-        List<Transaction> result = transactionServiceImpl.getTransactionsForUser(userId);
+        List<Transaction> result = transService.getTransactionsForUser(userId);
 
         // Assertions
         assertTrue(!result.isEmpty()); // Check if the result is present (not empty)

--- a/code/SoloSavingsApp/src/test/java/com/soloSavings/controller/TransactionControllerTest.java
+++ b/code/SoloSavingsApp/src/test/java/com/soloSavings/controller/TransactionControllerTest.java
@@ -11,6 +11,7 @@ import com.soloSavings.serviceImpl.TransactionServiceImpl;
 import jakarta.annotation.Resource;
 
 
+import static com.soloSavings.utils.Constants.INTERNAL_SERVER_ERROR;
 import static org.mockito.ArgumentMatchers.any;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -118,8 +119,8 @@ public class TransactionControllerTest {
         Double thisMonthIncome = 1000.0; // Set your expected this month's income here
 
         // Mock
-        when(transService.getThisMonthIncome(user.getUser_id())).thenReturn(thisMonthIncome);
-        ResponseEntity<?> response = transController.getThisMonthIncome();
+        when(transService.getThisMonthTotalAmount(user.getUser_id(),TransactionType.CREDIT)).thenReturn(thisMonthIncome);
+        ResponseEntity<?> response = transController.getThisMonthTotalAmount(TransactionType.CREDIT);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -127,17 +128,15 @@ public class TransactionControllerTest {
     }
     @Test
     public void testGetThisMonthIncomeWithInvalidRequest() throws TransactionException {
-        String errorMessage = "Invalid request";
-
         // Mock
-        when(transService.getThisMonthIncome(user.getUser_id()))
-                .thenThrow(new TransactionException(errorMessage));
+        when(transService.getThisMonthTotalAmount(user.getUser_id(),TransactionType.CREDIT))
+                .thenThrow(new TransactionException(INTERNAL_SERVER_ERROR));
 
-        ResponseEntity<?> response = transController.getThisMonthIncome();
+        ResponseEntity<?> response = transController.getThisMonthTotalAmount(TransactionType.CREDIT);
 
         // Assert
-        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
-        assertEquals(errorMessage, response.getBody());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(INTERNAL_SERVER_ERROR, response.getBody());
     }
 
     @Test
@@ -146,8 +145,8 @@ public class TransactionControllerTest {
         Double thisMonthExpense = 500.0;
 
         // Mock
-        when(transService.getThisMonthExpense(user.getUser_id())).thenReturn(thisMonthExpense);
-        ResponseEntity<?> response = transController.getThisMonthExpense();
+        when(transService.getThisMonthTotalAmount(user.getUser_id(),TransactionType.DEBIT)).thenReturn(thisMonthExpense);
+        ResponseEntity<?> response = transController.getThisMonthTotalAmount(TransactionType.DEBIT);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -155,17 +154,15 @@ public class TransactionControllerTest {
     }
     @Test
     public void testGetThisMonthExpenseWithInvalidRequest() throws TransactionException {
-        String errorMessage = "Invalid request";
-
         // Mock
-        when(transService.getThisMonthExpense(user.getUser_id()))
-                .thenThrow(new TransactionException(errorMessage));
+        when(transService.getThisMonthTotalAmount(user.getUser_id(),TransactionType.DEBIT))
+                .thenThrow(new TransactionException(INTERNAL_SERVER_ERROR));
 
-        ResponseEntity<?> response = transController.getThisMonthExpense();
+        ResponseEntity<?> response = transController.getThisMonthTotalAmount(TransactionType.DEBIT);
 
         // Assert
-        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
-        assertEquals(errorMessage, response.getBody());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals(INTERNAL_SERVER_ERROR, response.getBody());
     }
     
     

--- a/code/SoloSavingsApp/src/test/java/com/soloSavings/controller/UserAuthenticationControllerTest.java
+++ b/code/SoloSavingsApp/src/test/java/com/soloSavings/controller/UserAuthenticationControllerTest.java
@@ -20,6 +20,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
+
+import static com.soloSavings.utils.Constants.INVALID_USERNAME_OR_PASSWORD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -88,6 +90,6 @@ public class UserAuthenticationControllerTest {
         ResponseEntity<?> response = userAuthController.loginUser(loginData);
 
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        assertEquals("Invalid email or password", response.getBody());
+        assertEquals(INVALID_USERNAME_OR_PASSWORD, response.getBody());
     }
 }

--- a/code/SoloSavingsApp/src/test/java/com/soloSavings/integration/TransactionApiIntegrationTest.java
+++ b/code/SoloSavingsApp/src/test/java/com/soloSavings/integration/TransactionApiIntegrationTest.java
@@ -148,7 +148,7 @@ public class TransactionApiIntegrationTest {
 
     @Test
     public void testGetThisMonthExpense() throws TransactionException {
-        Double initThisMonthExpense = transactionService.getThisMonthExpense(commonUser.getUser_id());
+        Double initThisMonthExpense = transactionService.getThisMonthTotalAmount(commonUser.getUser_id(),TransactionType.DEBIT);
         Transaction tran1 = new Transaction(null,commonUser.getUser_id(),"", TransactionType.DEBIT,150.0, LocalDate.now());
         Transaction tran2 = new Transaction(null,commonUser.getUser_id(),"", TransactionType.DEBIT,150.0, null);
         transactionRepository.save(tran1);
@@ -156,7 +156,7 @@ public class TransactionApiIntegrationTest {
         Double expectedExpense = initThisMonthExpense + tran1.getAmount();
 
         HttpEntity<Transaction> request = new HttpEntity<>(headers);
-        ResponseEntity<Double> response = restTemplate.exchange("/api/transaction/monthly/expense", HttpMethod.GET,request,Double.class);
+        ResponseEntity<Double> response = restTemplate.exchange("/api/transaction/thismonth/DEBIT", HttpMethod.GET,request,Double.class);
 
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -165,7 +165,7 @@ public class TransactionApiIntegrationTest {
 
     @Test
     public void testGetThisMonthIncome() throws TransactionException {
-        Double initThisMonthIncome = transactionService.getThisMonthIncome(commonUser.getUser_id());
+        Double initThisMonthIncome = transactionService.getThisMonthTotalAmount(commonUser.getUser_id(),TransactionType.CREDIT);
         Transaction tran1 = new Transaction(null,commonUser.getUser_id(),"", TransactionType.CREDIT,150.0, LocalDate.now());
         Transaction tran2 = new Transaction(null,commonUser.getUser_id(),"", TransactionType.CREDIT,150.0, null);
         Transaction tran3 = new Transaction(null,commonUser.getUser_id(),"", TransactionType.CREDIT,100.0, LocalDate.now());
@@ -175,7 +175,7 @@ public class TransactionApiIntegrationTest {
         Double expectedIncome = initThisMonthIncome+tran1.getAmount()+tran3.getAmount();
 
         HttpEntity<Transaction> request = new HttpEntity<>(headers);
-        ResponseEntity<Double> response = restTemplate.exchange("/api/transaction/monthly/income", HttpMethod.GET,request,Double.class);
+        ResponseEntity<Double> response = restTemplate.exchange("/api/transaction/thismonth/CREDIT", HttpMethod.GET,request,Double.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isEqualTo(expectedIncome);

--- a/code/SoloSavingsApp/src/test/java/com/soloSavings/service/TransactionServiceTest.java
+++ b/code/SoloSavingsApp/src/test/java/com/soloSavings/service/TransactionServiceTest.java
@@ -11,14 +11,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -180,6 +183,28 @@ public class TransactionServiceTest {
         Assertions.assertThrows(TransactionException.class, () -> {
             transactionService.getTransactionsByType(userId, transactionType);
         });
+    }
+
+    @Test
+    public void testGetMonthlyAnalyticsByYear() throws TransactionException {
+        TransactionService tranServiceSpy = Mockito.spy(TransactionService.class);
+        Integer year = 2023;
+        Double amountEachMonth = 100.00;
+
+        when(tranServiceSpy.calculateMonthlyAmount(any(Integer.class),any(Integer.class),any(Integer.class),any(TransactionType.class)))
+                .thenReturn(amountEachMonth);
+
+        List<Map<Object, Object>> list = transactionService.getMonthlyAnalyticsByYear(1,year,TransactionType.CREDIT);
+
+        // list will have 12 maps, each contains an entry of label and an entry of data point
+        assertEquals(12,list.size());
+
+        for(Map<Object, Object> map : list){
+            assertTrue(map.containsKey("label"));
+            assertTrue(map.containsKey("y"));
+            assertTrue(map.containsValue(amountEachMonth));
+
+        }
     }
 
 }

--- a/code/SoloSavingsApp/src/test/java/com/soloSavings/service/TransactionServiceTest.java
+++ b/code/SoloSavingsApp/src/test/java/com/soloSavings/service/TransactionServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -112,7 +113,7 @@ public class TransactionServiceTest {
     }
 
     @Test
-    public void testGetThisMonthExpense(){
+    public void testGetThisMonthExpense() throws TransactionException {
         //Given
         List<Transaction> transactions = new ArrayList<>();
         Transaction trans1 = new Transaction(null,null,null, null,100.00,null);
@@ -122,15 +123,15 @@ public class TransactionServiceTest {
         Double expectedAmount = trans1.getAmount()+trans2.getAmount();
 
         //When
-        when(transactionRepository.findByCurrentMonth(any(TransactionType.class))).thenReturn(transactions);
-        Double actualAmount = transactionService.getThisMonthExpense(1);
+        when(transactionRepository.findByMonthAndType(anyInt(),anyInt(),any(TransactionType.class),anyInt())).thenReturn(transactions);
+        Double actualAmount = transactionService.getThisMonthTotalAmount(1,TransactionType.CREDIT);
 
         //Then
         assertEquals(expectedAmount,actualAmount);
     }
 
     @Test
-    public void testGetThisMonthIncome(){
+    public void testGetThisMonthIncome() throws TransactionException {
         //Given
         List<Transaction> transactions = new ArrayList<>();
         Transaction trans1 = new Transaction(null,null,null, null,100.00,null);
@@ -140,8 +141,8 @@ public class TransactionServiceTest {
         Double expectedAmount = trans1.getAmount()+trans2.getAmount();
 
         //When
-        when(transactionRepository.findByCurrentMonth(any(TransactionType.class))).thenReturn(transactions);
-        Double actualAmount = transactionService.getThisMonthIncome(1);
+        when(transactionRepository.findByMonthAndType(anyInt(),anyInt(),any(TransactionType.class),anyInt())).thenReturn(transactions);
+        Double actualAmount = transactionService.getThisMonthTotalAmount(1,TransactionType.CREDIT);
 
         //Then
         assertEquals(expectedAmount,actualAmount);

--- a/code/SoloSavingsApp/src/test/resources/application.properties
+++ b/code/SoloSavingsApp/src/test/resources/application.properties
@@ -1,0 +1,13 @@
+# Gmail SMTP Properties
+spring.mail.host=aspmx.l.google.com
+spring.mail.port=25
+spring.mail.username=notification.solosavings@gmail.com
+spring.mail.password=mlwucjcqjmggmif
+
+# Properties
+spring.mail.properties.mail.transport.protocol=smtp
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.ssl.trust=aspmx.l.google.com
+spring.mail.properties.mail.smtp.auth.mechanisms=PLAIN

--- a/code/SoloSavingsApp/transaction_history.csv
+++ b/code/SoloSavingsApp/transaction_history.csv
@@ -1,3 +1,0 @@
-Transaction ID,User ID,Source,Transaction Type,Amount,Transaction Date
-2902,81,salary,CREDIT,1000.00,2023-10-07
-2903,81,Ice cream,DEBIT,250.00,2023-10-07

--- a/code/SoloSavingsApp/transaction_history.csv
+++ b/code/SoloSavingsApp/transaction_history.csv
@@ -1,0 +1,3 @@
+Transaction ID,User ID,Source,Transaction Type,Amount,Transaction Date
+2902,81,salary,CREDIT,1000.00,2023-10-07
+2903,81,Ice cream,DEBIT,250.00,2023-10-07


### PR DESCRIPTION
refactor to reduce duplicate code in 3 methods

fix the api call to get transaction balance with userid attached (Christian suggestion)

created  button on frontend and analytic page to show a chart for spending/income for each month this year

TODO:

- [x] unit test for the showing 12 months balance in this year
- [x] integration test for the new API created
